### PR TITLE
Changed output directoy

### DIFF
--- a/projects/msvc/GLideN64.vcxproj
+++ b/projects/msvc/GLideN64.vcxproj
@@ -46,7 +46,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <OutDir>$(SolutionDir)..\..\..\external\$(Platform)\</OutDir>
+    <OutDir>$(MSBuildProjectDirectory)\..\..\..\external\$(Platform)\</OutDir>
     <IntDir>$(SolutionDir)build\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_mupenplus'">

--- a/projects/msvc/libGLideNHQ.vcxproj
+++ b/projects/msvc/libGLideNHQ.vcxproj
@@ -46,7 +46,7 @@
     <IntDir>$(SolutionDir)build\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <TargetName>libGLideNHQ</TargetName>
     <TargetExt>.lib</TargetExt>
-    <OutDir>$(SolutionDir)..\..\..\external\$(Platform)\</OutDir>
+    <OutDir>$(MSBuildProjectDirectory)..\..\..\..\external\$(Platform)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/projects/msvc/osal.vcxproj
+++ b/projects/msvc/osal.vcxproj
@@ -47,7 +47,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <OutDir>$(SolutionDir)..\..\..\external\$(Platform)\</OutDir>
+    <OutDir>$(MSBuildProjectDirectory)\..\..\..\external\$(Platform)\</OutDir>
     <IntDir>$(SolutionDir)build\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -101,7 +101,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-    <PropertyGroup Condition="'$(Configuration)'=='Release'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <TargetName>osal</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
This is needed to add the GLidenN64 project to the OOT solution.
Compilation from GLideN64.sln works as before.