### PR TITLE
Aspect ratio 4:3

### DIFF
--- a/src/DisplayLoadProgress.cpp
+++ b/src/DisplayLoadProgress.cpp
@@ -11,6 +11,7 @@
 
 void displayLoadProgress(const wchar_t *format, ...)
 {
+#ifndef NO_LOAD_PROGRESS_DISPLAY
 	va_list args;
 	wchar_t wbuf[INFO_BUF];
 	char buf[INFO_BUF];
@@ -46,4 +47,5 @@ void displayLoadProgress(const wchar_t *format, ...)
 
 	if (pBuffer != nullptr)
 		gfxContext.bindFramebuffer(graphics::bufferTarget::DRAW_FRAMEBUFFER, pBuffer->m_FBO);
+#endif
 }

--- a/src/DisplayWindow.h
+++ b/src/DisplayWindow.h
@@ -38,6 +38,7 @@ public:
 	bool isFullscreen() const { return m_bFullscreen; }
 	bool isAdjustScreen() const { return m_bAdjustScreen; }
 	bool isResizeWindow() const { return m_bResizeWindow; }
+	void forceResizeWindow() { _resizeWindow(); }
 
 	GraphicsDrawer & getDrawer() { return m_drawer; }
 

--- a/src/DisplayWindow.h
+++ b/src/DisplayWindow.h
@@ -38,7 +38,7 @@ public:
 	bool isFullscreen() const { return m_bFullscreen; }
 	bool isAdjustScreen() const { return m_bAdjustScreen; }
 	bool isResizeWindow() const { return m_bResizeWindow; }
-	void forceResizeWindow() { _resizeWindow(); }
+	void forceResizeWindow() { m_bResizeWindow = true; resizeWindow(); }
 
 	GraphicsDrawer & getDrawer() { return m_drawer; }
 

--- a/src/native/Native.cpp
+++ b/src/native/Native.cpp
@@ -97,11 +97,16 @@ extern "C"
     void gfx_resize(long width, long height)
     {
         g_originalWidth = width;
-        g_width  = width;
+
+        if (config.frameBufferEmulation.aspect == 1)//Running in 4:3 mode?
+            g_width = (height*4)/3;
+        else
+            g_width = width;
         g_height = height;
-        config.video.windowedWidth  = g_width;
-        config.video.windowedHeight = g_height;
-        dwnd().setWindowSize(g_width, g_height);
+
+        config.video.windowedWidth  = width;
+        config.video.windowedHeight = height;
+        dwnd().setWindowSize(width, height);
     }
 }
 


### PR DESCRIPTION
Added `gfx_force_43` to switch the aspect ratio to 4:3 on the fly.
Calling `gfx_force_43(bool)` enables/disables 4:3 mode.

Also added NO_LOAD_PROGRESS_DISPLAY to disable the loading messages.