### PR TITLE
Fixes GLideN64 crashes

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -300,8 +300,11 @@ void CombinerInfo::setCombine(u64 _mux )
 		m_pCurrent = iter->second;
 	} else {
 		m_pCurrent = Combiner_Compile(key);
-		m_pCurrent->update(true);
-		m_combiners[m_pCurrent->getKey()] = m_pCurrent;
+		if (m_pCurrent)
+		{
+			m_pCurrent->update(true);
+			m_combiners[m_pCurrent->getKey()] = m_pCurrent;
+		}
 	}
 	m_bChanged = true;
 }

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -54,7 +54,8 @@ void Context::destroy()
 
 void Context::setClampMode(ClampMode _mode)
 {
-	m_impl->setClampMode(_mode);
+	if (m_impl)
+		m_impl->setClampMode(_mode);
 }
 
 ClampMode Context::getClampMode()
@@ -64,7 +65,8 @@ ClampMode Context::getClampMode()
 
 void Context::enable(EnableParam _parameter, bool _enable)
 {
-	m_impl->enable(_parameter, _enable);
+	if (m_impl)
+		m_impl->enable(_parameter, _enable);
 }
 
 u32 Context::isEnabled(EnableParam _parameter)
@@ -79,117 +81,140 @@ void Context::cullFace(CullModeParam _parameter)
 
 void Context::enableDepthWrite(bool _enable)
 {
-	m_impl->enableDepthWrite(_enable);
+	if (m_impl)
+		m_impl->enableDepthWrite(_enable);
 }
 
 void Context::setDepthCompare(CompareParam _mode)
 {
-	m_impl->setDepthCompare(_mode);
+	if (m_impl)
+		m_impl->setDepthCompare(_mode);
 }
 
 void Context::setViewport(s32 _x, s32 _y, s32 _width, s32 _height)
 {
-	m_impl->setViewport(_x, _y, _width, _height);
+	if (m_impl)
+		m_impl->setViewport(_x, _y, _width, _height);
 }
 
 void Context::setScissor(s32 _x, s32 _y, s32 _width, s32 _height)
 {
-	m_impl->setScissor(_x, _y, _width, _height);
+	if (m_impl)
+		m_impl->setScissor(_x, _y, _width, _height);
 }
 
 void Context::setBlending(BlendParam _sfactor, BlendParam _dfactor)
 {
-	m_impl->setBlending(_sfactor, _dfactor);
+	if (m_impl)
+		m_impl->setBlending(_sfactor, _dfactor);
 }
 
 void graphics::Context::setBlendingSeparate(BlendParam _sfactorcolor, BlendParam _dfactorcolor, BlendParam _sfactoralpha, BlendParam _dfactoralpha)
 {
-	m_impl->setBlendingSeparate(_sfactorcolor, _dfactorcolor, _sfactoralpha, _dfactoralpha);
+	if (m_impl)
+		m_impl->setBlendingSeparate(_sfactorcolor, _dfactorcolor, _sfactoralpha, _dfactoralpha);
 }
 
 void Context::setBlendColor(f32 _red, f32 _green, f32 _blue, f32 _alpha)
 {
-	m_impl->setBlendColor(_red, _green, _blue, _alpha);
+	if (m_impl)
+		m_impl->setBlendColor(_red, _green, _blue, _alpha);
 }
 
 void Context::clearColorBuffer(f32 _red, f32 _green, f32 _blue, f32 _alpha)
 {
-	m_impl->clearColorBuffer(_red, _green, _blue, _alpha);
+	if (m_impl)
+		m_impl->clearColorBuffer(_red, _green, _blue, _alpha);
 }
 
 void Context::clearDepthBuffer()
 {
-	m_impl->clearDepthBuffer();
+	if (m_impl)
+		m_impl->clearDepthBuffer();
 }
 
 void Context::setPolygonOffset(f32 _factor, f32 _units)
 {
-	m_impl->setPolygonOffset(_factor, _units);
+	if (m_impl)
+		m_impl->setPolygonOffset(_factor, _units);
 }
 
 ObjectHandle Context::createTexture(Parameter _target)
 {
+	if (!m_impl) return ObjectHandle(0);
 	return m_impl->createTexture(_target);
 }
 
 void Context::deleteTexture(ObjectHandle _name)
 {
-	m_impl->deleteTexture(_name);
+	if (m_impl)
+		m_impl->deleteTexture(_name);
 }
 
 void Context::init2DTexture(const InitTextureParams & _params)
 {
-	m_impl->init2DTexture(_params);
+	if (m_impl)
+		m_impl->init2DTexture(_params);
 }
 
 void Context::update2DTexture(const UpdateTextureDataParams & _params)
 {
-	m_impl->update2DTexture(_params);
+	if (m_impl)
+		m_impl->update2DTexture(_params);
 }
 
 void Context::setTextureParameters(const TexParameters & _parameters)
 {
-	m_impl->setTextureParameters(_parameters);
+	if (m_impl)
+		m_impl->setTextureParameters(_parameters);
 }
 
 void Context::bindTexture(const BindTextureParameters & _params)
 {
-	m_impl->bindTexture(_params);
+	if (m_impl)
+		m_impl->bindTexture(_params);
 }
 
 void Context::setTextureUnpackAlignment(s32 _param)
 {
-	m_impl->setTextureUnpackAlignment(_param);
+	if (m_impl)
+		m_impl->setTextureUnpackAlignment(_param);
 }
 
 s32 Context::getTextureUnpackAlignment() const
 {
+	if (!m_impl) return 0;
 	return m_impl->getTextureUnpackAlignment();
 }
 
 s32 Context::getMaxTextureSize() const
 {
-	return m_impl->getMaxTextureSize();
+	if (!m_impl) return 0;
+		return m_impl->getMaxTextureSize();
 }
 
 f32 Context::getMaxAnisotropy() const
 {
+	if (!m_impl) return 0.0f;
 	return m_impl->getMaxAnisotropy();
 }
 
 void Context::bindImageTexture(const BindImageTextureParameters & _params)
 {
-	m_impl->bindImageTexture(_params);
+	if (m_impl)
+		m_impl->bindImageTexture(_params);
 }
 
 u32 Context::convertInternalTextureFormat(u32 _format) const
 {
+	if (!m_impl) return 0;
 	return m_impl->convertInternalTextureFormat(_format);
 }
 
 void Context::textureBarrier()
 {
-	m_impl->textureBarrier();
+	if (m_impl)
+		m_impl->textureBarrier();
 }
 
 /*---------------Framebuffer-------------*/
@@ -201,17 +226,20 @@ const FramebufferTextureFormats & Context::getFramebufferTextureFormats()
 
 ObjectHandle Context::createFramebuffer()
 {
+	if (!m_impl) return ObjectHandle(0);
 	return m_impl->createFramebuffer();
 }
 
 void Context::deleteFramebuffer(ObjectHandle _name)
 {
-	m_impl->deleteFramebuffer(_name);
+	if (m_impl)
+		m_impl->deleteFramebuffer(_name);
 }
 
 void Context::bindFramebuffer(BufferTargetParam _target, ObjectHandle _name)
 {
-	m_impl->bindFramebuffer(_target, _name);
+	if (m_impl)
+		m_impl->bindFramebuffer(_target, _name);
 }
 
 ObjectHandle Context::createRenderbuffer()
@@ -221,12 +249,14 @@ ObjectHandle Context::createRenderbuffer()
 
 void Context::initRenderbuffer(const InitRenderbufferParams & _params)
 {
-	m_impl->initRenderbuffer(_params);
+	if (m_impl)
+		m_impl->initRenderbuffer(_params);
 }
 
 void Context::addFrameBufferRenderTarget(const FrameBufferRenderTarget & _params)
 {
-	m_impl->addFrameBufferRenderTarget(_params);
+	if (m_impl)
+		m_impl->addFrameBufferRenderTarget(_params);
 }
 
 bool Context::blitFramebuffers(const BlitFramebuffersParams & _params)
@@ -236,7 +266,8 @@ bool Context::blitFramebuffers(const BlitFramebuffersParams & _params)
 
 void Context::setDrawBuffers(u32 _num)
 {
-	m_impl->setDrawBuffers(_num);
+	if (m_impl)
+		m_impl->setDrawBuffers(_num);
 }
 
 PixelReadBuffer * Context::createPixelReadBuffer(size_t _sizeInBytes)
@@ -253,93 +284,110 @@ ColorBufferReader * Context::createColorBufferReader(CachedTexture * _pTexture)
 
 bool Context::isCombinerProgramBuilderObsolete()
 {
+	if (!m_impl) return false;
 	return m_impl->isCombinerProgramBuilderObsolete();
-
 }
 
 void Context::resetCombinerProgramBuilder()
 {
-	m_impl->resetCombinerProgramBuilder();
+	if (m_impl)
+		m_impl->resetCombinerProgramBuilder();
 }
 
 CombinerProgram * Context::createCombinerProgram(Combiner & _color, Combiner & _alpha, const CombinerKey & _key)
 {
+	if (!m_impl) return nullptr;
 	return m_impl->createCombinerProgram(_color, _alpha, _key);
 }
 
 bool Context::saveShadersStorage(const Combiners & _combiners)
 {
+	if (!m_impl) return false;
 	return m_impl->saveShadersStorage(_combiners);
 }
 
 bool Context::loadShadersStorage(Combiners & _combiners)
 {
+	if (!m_impl) return false;
 	return m_impl->loadShadersStorage(_combiners);
 }
 
 ShaderProgram * Context::createDepthFogShader()
 {
+	if (!m_impl) return nullptr;
 	return m_impl->createDepthFogShader();
 }
 
 TexrectDrawerShaderProgram * Context::createTexrectDrawerDrawShader()
 {
+	if (!m_impl) return nullptr;
 	return m_impl->createTexrectDrawerDrawShader();
 }
 
 ShaderProgram * Context::createTexrectDrawerClearShader()
 {
+	if (!m_impl) return nullptr;
 	return m_impl->createTexrectDrawerClearShader();
 }
 
 ShaderProgram * Context::createTexrectUpscaleCopyShader()
 {
+	if (!m_impl) return nullptr;
 	return m_impl->createTexrectUpscaleCopyShader();
 }
 
 ShaderProgram * Context::createTexrectColorAndDepthUpscaleCopyShader()
 {
+	if (!m_impl) return nullptr;
 	return m_impl->createTexrectColorAndDepthUpscaleCopyShader();
 }
 
 ShaderProgram * Context::createTexrectDownscaleCopyShader()
 {
-  return m_impl->createTexrectDownscaleCopyShader();
+	if (!m_impl) return nullptr;
+	return m_impl->createTexrectDownscaleCopyShader();
 }
 
 ShaderProgram * Context::createTexrectColorAndDepthDownscaleCopyShader()
 {
-  return m_impl->createTexrectColorAndDepthDownscaleCopyShader();
+	if (!m_impl) return nullptr;
+	return m_impl->createTexrectColorAndDepthDownscaleCopyShader();
 }
 
 ShaderProgram * Context::createGammaCorrectionShader()
 {
+	if (!m_impl) return nullptr;
 	return m_impl->createGammaCorrectionShader();
 }
 
 ShaderProgram * Context::createFXAAShader()
 {
+	if (!m_impl) return nullptr;
 	return m_impl->createFXAAShader();
 }
 
 TextDrawerShaderProgram * Context::createTextDrawerShader()
 {
+	if (!m_impl) return nullptr;
 	return m_impl->createTextDrawerShader();
 }
 
 void Context::resetShaderProgram()
 {
-	m_impl->resetShaderProgram();
+	if (m_impl)
+		m_impl->resetShaderProgram();
 }
 
 void Context::drawTriangles(const DrawTriangleParameters & _params)
 {
-	m_impl->drawTriangles(_params);
+	if (m_impl)
+		m_impl->drawTriangles(_params);
 }
 
 void Context::drawRects(const DrawRectParameters & _params)
 {
-	m_impl->drawRects(_params);
+	if (m_impl)
+		m_impl->drawRects(_params);
 }
 
 void Context::drawLine(f32 _width, SPVertex * _vertices)
@@ -349,20 +397,24 @@ void Context::drawLine(f32 _width, SPVertex * _vertices)
 
 f32 Context::getMaxLineWidth()
 {
+	if (!m_impl) return 0.0f;
 	return m_impl->getMaxLineWidth();
 }
 
 s32 Context::getMaxMSAALevel()
 {
+	if (!m_impl) return 0;
 	return m_impl->getMaxMSAALevel();
 }
 
 bool Context::isError() const
 {
+	if (!m_impl) return false;
 	return m_impl->isError();
 }
 
 bool Context::isFramebufferError() const
 {
+	if (!m_impl) return false;
 	return m_impl->isFramebufferError();
 }

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -292,6 +292,8 @@ namespace graphics {
 
 		bool isFramebufferError() const;
 
+		operator bool () const { return m_impl.get(); }
+
 		static bool Multisampling;
 		static bool BlitFramebuffer;
 		static bool WeakBlitFramebuffer;

--- a/src/NoiseTexture.cpp
+++ b/src/NoiseTexture.cpp
@@ -106,6 +106,8 @@ void NoiseTexture::_fillTextureData()
 
 void NoiseTexture::init()
 {
+	if (!gfxContext)
+		return;
 	if (m_texData[0].empty())
 		_fillTextureData();
 

--- a/src/TexrectDrawer.cpp
+++ b/src/TexrectDrawer.cpp
@@ -36,6 +36,9 @@ TexrectDrawer::TexrectDrawer()
 
 void TexrectDrawer::init()
 {
+	if (!gfxContext)
+		return;
+
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
 
 	m_FBO = gfxContext.createFramebuffer();
@@ -49,7 +52,7 @@ void TexrectDrawer::init()
 	m_pTexture->maskT = 0;
 	m_pTexture->mirrorS = 0;
 	m_pTexture->mirrorT = 0;
-	m_pTexture->width = 640;
+	m_pTexture->width  = 640;
 	m_pTexture->height = 580;
 	m_pTexture->textureBytes = m_pTexture->width * m_pTexture->height * fbTexFormats.colorFormatBytes;
 


### PR DESCRIPTION
This PR fixes a few places so that GLideN64 doesn't crashes any longer when the window is invalid.
These are all mostly null pointer checks.