### PR TITLE
Removed error message when `SetPixelFormat()` fails

### DIFF
--- a/src/Graphics/OpenGLContext/windows/WindowsWGL.cpp
+++ b/src/Graphics/OpenGLContext/windows/WindowsWGL.cpp
@@ -49,7 +49,7 @@ bool WindowsWGL::start()
 	if ((SetPixelFormat(hDC, pixelFormat, &pfd)) == FALSE) {
         auto err = GetLastError();
         auto currentFormat = GetPixelFormat(hDC);
-		MessageBoxW(hWnd, L"Error while setting pixel format!", pluginNameW, MB_ICONERROR | MB_OK);
+		//MessageBoxW(hWnd, L"Error while setting pixel format!", pluginNameW, MB_ICONERROR | MB_OK);
 	}
 
 	if ((hRC = wglCreateContext(hDC)) == NULL) {


### PR DESCRIPTION
There error message it not necessary since an error there, doesn't mean that we are unable to create an OpenGL context.
And if an OpenGL context can not be created, that error is handled anyway.