### PR TITLE
Fixed 2D graphics alignment problem

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -62,7 +62,9 @@ void Config::resetToDefaults()
 	generalEmulation.enableFragmentDepthWrite = 1;
 #endif
 
-	graphics2D.correctTexrectCoords = tcDisable;
+	//Fix the texture coordinates when two 2D rectangles are next to each other
+	//The game creates a gap of half a pixel
+	graphics2D.correctTexrectCoords = tcSmart;
 	graphics2D.enableNativeResTexrects = NativeResTexrectsMode::ntDisable;
 	graphics2D.bgMode = BGMode::bgStripped;
 	graphics2D.enableTexCoordBounds = 0;

--- a/src/native/Native.cpp
+++ b/src/native/Native.cpp
@@ -139,10 +139,6 @@ extern "C" {
         RDRAMSize = (word)-1;
 
         api().RomOpen(romName);
-
-        //Fix the texture coordinates when two 2D rectangles are next to each other
-        //The game creates a gap of half a pixel
-        config.graphics2D.correctTexrectCoords = 1;
     }
 
     void gfx_force_43(bool enable) {

--- a/src/native/Native.cpp
+++ b/src/native/Native.cpp
@@ -139,6 +139,10 @@ extern "C" {
         RDRAMSize = (word)-1;
 
         api().RomOpen(romName);
+
+        //Fix the texture coordinates when two 2D rectangles are next to each other
+        //The game creates a gap of half a pixel
+        config.graphics2D.correctTexrectCoords = 1;
     }
 
     void gfx_force_43(bool enable) {


### PR DESCRIPTION
Enabled `correctTexrectCoords` flag.
This fixes issue #146 in OOT.

The game uses two rectangles to sometimes display textures.
There is a gap of half a pixel which shows up when playing the game at a higher than 320x240 resolution.