### PR TITLE
Fixed an infinite loop

### DIFF
--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -33,7 +33,11 @@ RSPInfo		RSP;
 static
 void _ProcessDList()
 {
+#ifdef NATIVE
+	for (int i = 0; !RSP.halt && i < 1000*1000*1000; ++i) {
+#else
 	while (!RSP.halt) {
+#endif
 #ifndef NATIVE
 		if ((RSP.PC[RSP.PCi] + sizeof(Gwords)) > RDRAMSize) {
 #ifdef DEBUG_DUMP


### PR DESCRIPTION
Introduced an upper limit to the loop in `_ProcessDList`.
This fixes a rare endless loop in OOT.