### PR TITLE
Added Function to set Overscan

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -85,7 +85,20 @@ void Config::resetToDefaults()
 #else
 	frameBufferEmulation.fbInfoDisabled = 1;
 #endif
+
+#ifdef NATIVE
+	frameBufferEmulation.enableOverscan = 1;
+	config.frameBufferEmulation.overscanPAL.left    = 4;
+	config.frameBufferEmulation.overscanPAL.right   = 4;
+	config.frameBufferEmulation.overscanPAL.top     = 0;
+	config.frameBufferEmulation.overscanPAL.bottom  = 3;
+	config.frameBufferEmulation.overscanNTSC.left   = 4;
+	config.frameBufferEmulation.overscanNTSC.right  = 4;
+	config.frameBufferEmulation.overscanNTSC.top    = 0;
+	config.frameBufferEmulation.overscanNTSC.bottom = 3;
+#else
 	frameBufferEmulation.enableOverscan = 0;
+#endif
 
 	textureFilter.txFilterMode = 0;
 	textureFilter.txEnhancementMode = 0;

--- a/src/native/Native.cpp
+++ b/src/native/Native.cpp
@@ -158,6 +158,18 @@ extern "C" {
         g_width = newWidth;
     }
 
+    void gfx_set_overscan(int left, int top, int right, int bottom) {
+        config.frameBufferEmulation.enableOverscan      = 1;
+        config.frameBufferEmulation.overscanPAL.left    = left;
+        config.frameBufferEmulation.overscanPAL.right   = right;
+        config.frameBufferEmulation.overscanPAL.top     = top;
+        config.frameBufferEmulation.overscanPAL.bottom  = bottom;
+        config.frameBufferEmulation.overscanNTSC.left   = left;
+        config.frameBufferEmulation.overscanNTSC.right  = right;
+        config.frameBufferEmulation.overscanNTSC.top    = top;
+        config.frameBufferEmulation.overscanNTSC.bottom = bottom;
+    }
+
     void gfx_shutdown() {
         RDRAMSize = 0;
         api().RomClosed();


### PR DESCRIPTION
This PR adds a new function `gfx_set_overscan`.
This function can be used to enable the overscan feature in GlideN64.
In OOT this can be used to remove the black borders (at the left, right and bottom).

See https://gliden64.blogspot.com/2018/05/overscan.html for an overview of GlideN64's overscan feature.
Notice that the size of the border depends on the game, so it make sense to set the border size in OOT instead of in GLideN64's configuration file.