### PR TITLE
Frame Buffer Emulation Tiny Fix

### DIFF
--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -87,7 +87,11 @@ void VI_UpdateSize()
 //	const int fsaa = ((*REG.VI_STATUS) >> 8) & 3;
 //	const int divot = ((*REG.VI_STATUS) >> 4) & 1;
 	FrameBufferList & fbList = frameBufferList();
-	FrameBuffer * pBuffer = fbList.findBuffer(VI.lastOrigin & 0xffffff);
+#ifdef NATIVE
+	FrameBuffer* pBuffer = fbList.findBuffer(VI.lastOrigin);
+#else
+	FrameBuffer* pBuffer = fbList.findBuffer(VI.lastOrigin & 0xffffff);
+#endif
 	DepthBuffer * pDepthBuffer = pBuffer != nullptr ? pBuffer->m_pDepthBuffer : nullptr;
 	if (config.frameBufferEmulation.enable &&
 		((interlacedPrev != VI.interlaced) ||


### PR DESCRIPTION
This PR fixes a tiny mistake.
`VI.lastOrigin` contains a 32 bit address, hence the bitmask is a mistake.
As far as I am aware this doesn't change anything in OOT.